### PR TITLE
[POM] Bump quarkus versions to 1.3.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,11 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 
-		<quarkus.platform.version>1.2.1.Final</quarkus.platform.version>
-		<github.api.version>1.108</github.api.version>
+		<quarkus-universe-bom.version>1.3.0.Final</quarkus-universe-bom.version>
+		<github-api.version>1.108</github-api.version>
 		<bouncycastle.version>1.64</bouncycastle.version>
 		<jjwt.version>0.11.1</jjwt.version>
+		<commons-codec.version>1.14</commons-codec.version>
 
 		<wiremock.version>2.26.3</wiremock.version>
 		<assertj.version>3.15.0</assertj.version>
@@ -25,7 +26,7 @@
 		<jetty.version>9.4.27.v20200227</jetty.version>
 
 		<compiler-plugin.version>3.8.1</compiler-plugin.version>
-		<quarkus-plugin.version>1.2.1.Final</quarkus-plugin.version>
+		<quarkus-plugin.version>1.3.0.Final</quarkus-plugin.version>
 		<surefire-plugin.version>2.22.2</surefire-plugin.version>
 		<resources-plugin.version>3.1.0</resources-plugin.version>
 	</properties>
@@ -35,7 +36,7 @@
 			<dependency>
 				<groupId>io.quarkus</groupId>
 				<artifactId>quarkus-universe-bom</artifactId>
-				<version>${quarkus.platform.version}</version>
+				<version>${quarkus-universe-bom.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -60,13 +61,9 @@
 			<artifactId>quarkus-scheduler</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>io.quarkus</groupId>
-			<artifactId>quarkus-junit5</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>github-api</artifactId>
-			<version>${github.api.version}</version>
+			<version>${github-api.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
@@ -90,7 +87,17 @@
 			<version>${jjwt.version}</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>${commons-codec.version}</version>
+		</dependency>
 
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock-jre8</artifactId>

--- a/src/main/java/com/github/avano/pr/workflow/bus/Bus.java
+++ b/src/main/java/com/github/avano/pr/workflow/bus/Bus.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import io.vertx.axle.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.EventBus;
 
 /**
  * Wrapper around Vertx Eventbus + constants for destinations.

--- a/src/test/java/com/github/avano/pr/workflow/TestParent.java
+++ b/src/test/java/com/github/avano/pr/workflow/TestParent.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
 
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHUser;
@@ -40,8 +39,8 @@ import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
-import io.vertx.axle.core.eventbus.DeliveryContext;
-import io.vertx.axle.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.DeliveryContext;
+import io.vertx.mutiny.core.eventbus.EventBus;
 
 public class TestParent {
     public static final String TEST_REPO = "test/repo";
@@ -128,13 +127,6 @@ public class TestParent {
         // Return OK for PR patches (assigning assignees and stuff)
         stubFor(WireMock.put(urlPathMatching(PR_PATCH_URL))
             .willReturn(ok()));
-    }
-
-    @BeforeEach
-    public void printTestName(TestInfo info) {
-        if (info.getTestMethod().isPresent()) {
-            System.out.println("### Running " + info.getTestMethod().get());
-        }
     }
 
     @AfterEach


### PR DESCRIPTION
Also change `io.vertx.axle.core.eventbus.EventBus` to `io.vertx.mutiny.core.eventbus.EventBus` as the former is going to be removed